### PR TITLE
Refactor component props for uploads and packet processing

### DIFF
--- a/pdf-bookmark-packet-app/src/App.tsx
+++ b/pdf-bookmark-packet-app/src/App.tsx
@@ -34,7 +34,7 @@ const App = () => {
                 Process Packets
             </button>
             <PacketProcessor packets={packets} isProcessing={isProcessing} />
-            <CSVDownload packets={packets} />
+            <CSVDownload data={packets} />
         </div>
     );
 };

--- a/pdf-bookmark-packet-app/src/components/ConsoleInput.tsx
+++ b/pdf-bookmark-packet-app/src/components/ConsoleInput.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 
-const ConsoleInput: React.FC<{ onBookmarksParsed: (bookmarks: string[]) => void }> = ({ onBookmarksParsed }) => {
+interface ConsoleInputProps {
+    onParse: (bookmarks: string[]) => void;
+}
+
+const ConsoleInput: React.FC<ConsoleInputProps> = ({ onParse }) => {
     const [consoleOutput, setConsoleOutput] = useState('');
 
     const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -9,7 +13,7 @@ const ConsoleInput: React.FC<{ onBookmarksParsed: (bookmarks: string[]) => void 
 
     const handleParseBookmarks = () => {
         const bookmarks = parseBookmarks(consoleOutput);
-        onBookmarksParsed(bookmarks);
+        onParse(bookmarks);
         setConsoleOutput('');
     };
 

--- a/pdf-bookmark-packet-app/src/components/PDFUpload.tsx
+++ b/pdf-bookmark-packet-app/src/components/PDFUpload.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react';
 
-const PDFUpload: React.FC<{ onFileUpload: (file: File) => void }> = ({ onFileUpload }) => {
+interface PDFUploadProps {
+    onUpload: (file: File) => void;
+}
+
+const PDFUpload: React.FC<PDFUploadProps> = ({ onUpload }) => {
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
     const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (file && file.type === 'application/pdf') {
             setSelectedFile(file);
-            onFileUpload(file);
+            onUpload(file);
         } else {
             alert('Please upload a valid PDF file.');
         }

--- a/pdf-bookmark-packet-app/src/components/PacketProcessor.tsx
+++ b/pdf-bookmark-packet-app/src/components/PacketProcessor.tsx
@@ -1,25 +1,12 @@
-import React, { useState } from 'react';
-import { extractBookmarksFromPDF } from '../utils/pdfUtils';
+import React from 'react';
 import { generateCSV } from '../utils/csvUtils';
 
-const PacketProcessor: React.FC<{ pdfFile: File; bookmarks: string[] }> = ({ pdfFile, bookmarks }) => {
-    const [packets, setPackets] = useState<any[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
+interface PacketProcessorProps {
+    packets: any[];
+    isProcessing: boolean;
+}
 
-    const processPDF = async () => {
-        setLoading(true);
-        setError(null);
-        try {
-            const extractedPackets = await extractBookmarksFromPDF(pdfFile, bookmarks);
-            setPackets(extractedPackets);
-        } catch (err) {
-            setError('Error processing PDF: ' + (err as Error).message);
-        } finally {
-            setLoading(false);
-        }
-    };
-
+const PacketProcessor: React.FC<PacketProcessorProps> = ({ packets, isProcessing }) => {
     const handleDownloadCSV = () => {
         const csvData = generateCSV(packets);
         const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
@@ -31,21 +18,22 @@ const PacketProcessor: React.FC<{ pdfFile: File; bookmarks: string[] }> = ({ pdf
         document.body.removeChild(link);
     };
 
+    if (isProcessing) {
+        return <p>Processing...</p>;
+    }
+
+    if (packets.length === 0) {
+        return null;
+    }
+
     return (
         <div>
-            <button onClick={processPDF} disabled={loading}>
-                {loading ? 'Processing...' : 'Process PDF'}
-            </button>
-            {error && <p style={{ color: 'red' }}>{error}</p>}
-            {packets.length > 0 && (
-                <div>
-                    <h3>Processed Packets</h3>
-                    <pre>{JSON.stringify(packets, null, 2)}</pre>
-                    <button onClick={handleDownloadCSV}>Download CSV</button>
-                </div>
-            )}
+            <h3>Processed Packets</h3>
+            <pre>{JSON.stringify(packets, null, 2)}</pre>
+            <button onClick={handleDownloadCSV}>Download CSV</button>
         </div>
     );
 };
 
 export default PacketProcessor;
+


### PR DESCRIPTION
## Summary
- rename file upload handler prop to `onUpload`
- change console input to expose `onParse` callback
- simplify packet processor to display packets and CSV download

## Testing
- `npm test`
- `npm run build` *(fails: Could not find a required file. Name: index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96c6e44c832499e99a98facef2ed